### PR TITLE
format date YYYY/MM/DD

### DIFF
--- a/processLogs.py
+++ b/processLogs.py
@@ -52,16 +52,7 @@ def skipTo(fIn, searchString):
     return l
 
 def normalizeDate(date):
-    date = re.sub('[-. ]+','/',date)
-    date = re.sub('[.]+$','',date)
-    (y,m,d) = date.split('/')
-    if int(d) > 1969:
-        # dd.mm.yyyy
-        d,y = y,d
-    elif int(y) < 1970:
-        # dd.mm.yy
-        d,y = y,int(d)+2000
-    date = '%02d/%02d/%02d'%(int(y),int(m),int(d))
+    date = date[6:10] + '/' + date[0:2]  + '/' + date[3:5]
     return date
     
 
@@ -263,6 +254,7 @@ class Logbook:
             
         dates = days.keys()
         dates.sort()
+
         for d in dates:
             # check if date is in the correct interval
             if self.startDate and d < self.startDate:


### PR DESCRIPTION
Je n'arrive pas à trouver un format de date d'origine sur la page de log autre que "MM/DD/YYYY" en changeant la langue et la méthode normalizeDate() renvoie le format "YYYY/DD/MM" ce qui fausse un peu le dates.sort() au niveau des clés. Peut être aussi une mauvaise interprétation de ma part du choix de format de sortie utilisé par la suite. 

par exemple, voila un extrait du résultat du dates.sort() que je peux avoir de mon coté. 
`['2004/02/05', '2004/08/05', '2004/08/11', '2004/14/08', '2004/16/05', '2004/18/10', '2004/22/05', '2004/23/05', '2004/24/07',...]`
