### PR TITLE
refactoring method processLogs

### DIFF
--- a/processLogs.py
+++ b/processLogs.py
@@ -224,7 +224,7 @@ class Logbook:
         for tr in listTr:
             td = re.finditer('<td>(.*?)</td>',tr, re.S)
             listTd = [result.group(1) for result in td]
-            dateLog =  listTd[2].strip()
+            dateLog =  normalizeDate(listTd[2].strip())
             typeLog =  re.search('title="(.*)">',listTd[0]).group(1)
             idCache = re.search('guid=(.*?)"',listTd[3]).group(1)
             idLog = re.search('LUID=(.*?)"',listTd[5]).group(1)


### PR DESCRIPTION
Peut être un peu plus facile à suivre dans l'analyse des tags si évolution de la page à parser et cela permet aussi de s'affranchir de la méthode skipTo(). A voir !